### PR TITLE
only show rearrange arrows on hover

### DIFF
--- a/final/style.css
+++ b/final/style.css
@@ -50,9 +50,17 @@
   z-index: 5;
 }
 
+/* Hide arrows by default */
 .c-sidebar-group__rearrange-arrows {
   display: flex;
   align-items: center;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+/* Show arrows on hover over the sidebar group title */
+.c-sidebar-group__title:hover .c-sidebar-group__rearrange-arrows {
+  opacity: 1;
 }
 
 .c-sidebar-group__move-up path,


### PR DESCRIPTION
Personally, I prefer to only have the rearrange arrows visible when hovering over the group title and to otherwise hide them. This looks cleaner in my opinion as the color of the group title already changes on hover.