### PR TITLE
Add RequestTinter

### DIFF
--- a/workflows/RequestTinter.json
+++ b/workflows/RequestTinter.json
@@ -1,0 +1,543 @@
+{
+  "description": "Tints Requests",
+  "edition": 2,
+  "graph": {
+    "edges": [
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 0
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 2
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 5
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 1
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "true",
+          "node_id": 4
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 5
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 3
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 4
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "false",
+          "node_id": 2
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 1
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "false",
+          "node_id": 4
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 6
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 6
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 7
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 8
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 1
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "false",
+          "node_id": 7
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 9
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 9
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 10
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 11
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 1
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "true",
+          "node_id": 10
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 11
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "false",
+          "node_id": 10
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 1
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "true",
+          "node_id": 7
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 8
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "true",
+          "node_id": 13
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 14
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 12
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 13
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "false",
+          "node_id": 13
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 3
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 14
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 1
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "true",
+          "node_id": 2
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 12
+        }
+      }
+    ],
+    "nodes": [
+      {
+        "alias": "on_intercept_request",
+        "definition_id": "caido/on-intercept-request",
+        "display": {
+          "x": 0,
+          "y": -110
+        },
+        "id": 0,
+        "inputs": [],
+        "name": "On intercept request",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "passive_end",
+        "definition_id": "caido/passive-end",
+        "display": {
+          "x": 0,
+          "y": 320
+        },
+        "id": 1,
+        "inputs": [],
+        "name": "Passive End",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "in_scope",
+        "definition_id": "caido/in-scope",
+        "display": {
+          "x": 0,
+          "y": -10
+        },
+        "id": 2,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "In Scope",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "matches_httpql",
+        "definition_id": "caido/httpql-matches",
+        "display": {
+          "x": -160,
+          "y": 60
+        },
+        "id": 3,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "query",
+            "value": {
+              "data": "req.method.eq:\"POST\"",
+              "kind": "string"
+            }
+          }
+        ],
+        "name": "Matches POST",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "if_else",
+        "definition_id": "caido/if-else",
+        "display": {
+          "x": -160,
+          "y": 160
+        },
+        "id": 4,
+        "inputs": [
+          {
+            "alias": "condition",
+            "value": {
+              "data": "$matches_httpql.matches",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "If/Else",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "set_color",
+        "definition_id": "caido/color-set",
+        "display": {
+          "x": -160,
+          "y": 240
+        },
+        "id": 5,
+        "inputs": [
+          {
+            "alias": "color",
+            "value": {
+              "data": "#2196F3",
+              "kind": "string"
+            }
+          },
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "Set POST Color",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "matches_httpql_1",
+        "definition_id": "caido/httpql-matches",
+        "display": {
+          "x": 0,
+          "y": 60
+        },
+        "id": 6,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "query",
+            "value": {
+              "data": "req.method.eq:\"PUT\"",
+              "kind": "string"
+            }
+          }
+        ],
+        "name": "Matches PUT",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "if_else_1",
+        "definition_id": "caido/if-else",
+        "display": {
+          "x": 0,
+          "y": 160
+        },
+        "id": 7,
+        "inputs": [
+          {
+            "alias": "condition",
+            "value": {
+              "data": "$matches_httpql_1.matches",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "If/Else 1",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "set_color_1",
+        "definition_id": "caido/color-set",
+        "display": {
+          "x": 0,
+          "y": 240
+        },
+        "id": 8,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "color",
+            "value": {
+              "data": "#FFC107",
+              "kind": "string"
+            }
+          }
+        ],
+        "name": "Set PUT Color",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "matches_httpql_2",
+        "definition_id": "caido/httpql-matches",
+        "display": {
+          "x": 160,
+          "y": 60
+        },
+        "id": 9,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "query",
+            "value": {
+              "data": "req.method.eq:\"DELETE\"",
+              "kind": "string"
+            }
+          }
+        ],
+        "name": "Matches DELETE",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "if_else_2",
+        "definition_id": "caido/if-else",
+        "display": {
+          "x": 160,
+          "y": 160
+        },
+        "id": 10,
+        "inputs": [
+          {
+            "alias": "condition",
+            "value": {
+              "data": "$matches_httpql_2.matches",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "If/Else 2",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "set_color_2",
+        "definition_id": "caido/color-set",
+        "display": {
+          "x": 160,
+          "y": 240
+        },
+        "id": 11,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "color",
+            "value": {
+              "data": "#F44336",
+              "kind": "string"
+            }
+          }
+        ],
+        "name": "Set DELETE Color",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "matches_httpql_3",
+        "definition_id": "caido/httpql-matches",
+        "display": {
+          "x": -320,
+          "y": 60
+        },
+        "id": 12,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "query",
+            "value": {
+              "data": "req.method.eq:\"GET\"",
+              "kind": "string"
+            }
+          }
+        ],
+        "name": "Matches GET",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "if_else_3",
+        "definition_id": "caido/if-else",
+        "display": {
+          "x": -320,
+          "y": 160
+        },
+        "id": 13,
+        "inputs": [
+          {
+            "alias": "condition",
+            "value": {
+              "data": "$matches_httpql_3.matches",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "If/Else 3",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "set_color_3",
+        "definition_id": "caido/color-set",
+        "display": {
+          "x": -320,
+          "y": 240
+        },
+        "id": 14,
+        "inputs": [
+          {
+            "alias": "color",
+            "value": {
+              "data": "#4CAF50",
+              "kind": "string"
+            }
+          },
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "Set GET Color",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  "id": "c908f94e-a99e-4701-8c23-d4dfcb7b5205",
+  "kind": "passive",
+  "name": "RequestTinter"
+}


### PR DESCRIPTION
# RequestTinter

Author: [deathflash](https://x.com/deathflash1411) / [OsmSec](https://github.com/osmsec)

RequestTinter is a Caido workflow that applies color tints to in-scope HTTP requests, making it easier to identify them based on their respective methods as below:

| Method | Color           |
| ------ | --------------- |
| GET    | #4CAF50 (Green) |
| POST   | #2196F3 (Blue)  |
| PUT    | #FFC107 (Amber) |
| DELETE | #F44336 (Red)   |

Screenshot:

![RequestTinter](https://i.imgur.com/iUaFXxX.png)