### PR TITLE
Fix createSession issue in Share Replay Collections

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "evenbetter",
   "name": "EvenBetter",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Collection of tweaks and improvements for Caido",
   "author": {
     "name": "bebiks",


### PR DESCRIPTION
Fixes #65 by implementing the following in share-replay-collections:
- Validate connectionInfo before creating a session
- Use optional chaining and nullish coalescing to prevent type errors on null values
- Add try-catch error handling

Once I built this and loaded it into my Caido, I now have the original collection back:
<img width="513" height="225" alt="image" src="https://github.com/user-attachments/assets/d4092fe0-407d-4abd-b105-6df92024b27e" />
